### PR TITLE
add shorter sleep back to write_registers!

### DIFF
--- a/src/VMEGateways/sis3316_gateway.jl
+++ b/src/VMEGateways/sis3316_gateway.jl
@@ -403,9 +403,9 @@ function write_registers!(gw::SIS3316Gateway, addrs::AbstractVector{UInt32}, val
             for i in li_idxs
                 write_link_interface_register!(gw, addrs[i], values[i], timeout = timeout)
 
-                # sleep(0.005) # or yield() for a shorter pause
+                sleep(0.005) # or yield() for a shorter pause
             end
-            # sleep(0.05) # or yield() for a shorter pause
+            sleep(0.015) # or yield() for a shorter pause
 
             write_register_space!(gw, addrs[re_idxs], values[re_idxs], timeout = timeout)
         end


### PR DESCRIPTION
Removing all sleeps in `write_registers!` causes Struck to crash (data not taken, only way to solve is power cycling Struck) once every 1-3 days of continuous data taking with rates of ~3.6 kHz. 

Adding `sleep(0.005)` in line 406 (inside loop) seems to have no effect on data taking rate (vs having no `sleep` at all)

Adding any `sleep(t)` with `t > 0.01` in line 408 degrades data taking rate. `t = 0.015` seems to maximize stability while adding negligible deadtime.
With the sleep settings in this pull request I have only had 1 daq crash in the past 2 weeks of continuous data taking