### PR TITLE
Sleep

### DIFF
--- a/src/VMEGateways/sis3316_gateway.jl
+++ b/src/VMEGateways/sis3316_gateway.jl
@@ -403,9 +403,9 @@ function write_registers!(gw::SIS3316Gateway, addrs::AbstractVector{UInt32}, val
             for i in li_idxs
                 write_link_interface_register!(gw, addrs[i], values[i], timeout = timeout)
 
-                # sleep(0.005) # or yield() for a shorter pause
+                sleep(0.005) # or yield() for a shorter pause
             end
-            # sleep(0.05) # or yield() for a shorter pause
+            sleep(0.015) # or yield() for a shorter pause
 
             write_register_space!(gw, addrs[re_idxs], values[re_idxs], timeout = timeout)
         end

--- a/src/VMEGateways/sis3316_gateway.jl
+++ b/src/VMEGateways/sis3316_gateway.jl
@@ -405,7 +405,7 @@ function write_registers!(gw::SIS3316Gateway, addrs::AbstractVector{UInt32}, val
 
                 sleep(0.005) # or yield() for a shorter pause
             end
-            sleep(0.015) # or yield() for a shorter pause
+            sleep(0.02) # or yield() for a shorter pause
 
             write_register_space!(gw, addrs[re_idxs], values[re_idxs], timeout = timeout)
         end


### PR DESCRIPTION
Change in sleep time restores expected event rate with Cs source.
Sleeps shorter than 0.02 result in fatal STRUCK crashes (i.e. STRUCK has to be reset)
No such crashes were observed with 0.02 in the 3 months of data taking following the change. 